### PR TITLE
Add simple Chef script to setup 2G swap on Rails servers

### DIFF
--- a/swap/recipes/defeault.rb
+++ b/swap/recipes/defeault.rb
@@ -1,0 +1,10 @@
+bash 'setup swap' do
+  user 'root'
+  not_if { File.exists?('/var/swapfile') }
+  code<<-EOH
+    dd if=/dev/zero of=/var/swapfile bs=1M count=2048
+    chmod 600 /var/swapfile
+    mkswap /var/swapfile
+    swapon /var/swapfile
+  EOH
+end


### PR DESCRIPTION
Add a simple Chef script to setup a 2GB swap file in /var/swapfile for use by the Rails servers
