### PR TITLE
Tweak OpsWorks rails default database.yml.erb template

### DIFF
--- a/rails/templates/default/database.yml.erb
+++ b/rails/templates/default/database.yml.erb
@@ -1,0 +1,20 @@
+<% (['development', 'production'] + [@environment]).uniq.each do |env| -%>
+<%= env %>:
+  adapter: <%= @database[:adapter].to_s.inspect %>
+  database: <%= @database[:database].to_s.inspect %>
+  encoding: <%= (@database[:encoding] || 'utf8').to_s.inspect %>
+  host: <%= (@database[:host] || 'localhost').to_s.inspect %>
+  username: <%= @database[:username].to_s.inspect %>
+  password: <%= @database[:password].to_s.inspect %>
+  reconnect: <%= @database[:reconnect] ? 'true' : 'false' %>
+<% if @database[:pool] -%>
+  pool: <%= @database[:pool].to_i.inspect %>
+<% end -%>
+<% if @database[:port] -%>
+  port: <%= @database[:port].to_i.inspect %>
+<% end -%>
+<% if @database[:strict] -%>
+  strict: <%= @database[:strict] %>
+<% end -%>
+
+<% end %>


### PR DESCRIPTION
Add optional configuration of 'strict' to template, as the R4 default of true is causing errors where we previously silently truncated.