### PR TITLE
Remove data-directory configuration during sunspot-solr start/stop

### DIFF
--- a/sunspot_solr/recipes/default.rb
+++ b/sunspot_solr/recipes/default.rb
@@ -32,7 +32,6 @@ node[:deploy].each do |application, deploy|
       :user => deploy[:user],
       :group => deploy[:group],
       :timeout => 30,
-      :data_dir => data_dir
     )
   end
 end

--- a/sunspot_solr/templates/default/sunspot_solr.monitrc.erb
+++ b/sunspot_solr/templates/default/sunspot_solr.monitrc.erb
@@ -1,5 +1,5 @@
 check process <%= @app %>_sunspot_solr with pidfile <%= @dir %>/shared/pids/sunspot-solr.pid
-  start program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> bundle exec sunspot-solr start --data-directory=<%= @data_dir %> --pid-dir=<%= @dir %>/shared/pids --solr-home=<%= @dir %>/current/solr'"
+  start program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> bundle exec sunspot-solr start --pid-dir=<%= @dir %>/shared/pids --solr-home=<%= @dir %>/current/solr'"
     as uid <%= @user %> and gid <%= @group %> with timeout <%= @timeout %> seconds
-  stop program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> bundle exec sunspot-solr stop --data-directory=<%= @data_dir %> --pid-dir=<%= @dir %>/shared/pids --solr-home=<%= @dir %>/current/solr'"
+  stop program = "/bin/sh -c 'cd <%= @dir %>/current; /usr/bin/env PATH=/usr/local/bin:$PATH RAILS_ENV=<%= @env %> bundle exec sunspot-solr stop --pid-dir=<%= @dir %>/shared/pids --solr-home=<%= @dir %>/current/solr'"
     as uid <%= @user %> and gid <%= @group %> with timeout <%= @timeout %> seconds


### PR DESCRIPTION
--data-directory is no longer a valid configuration for sunspot-solr. Instead, it is now set using dataDir in default/core.properties.

See https://cwiki.apache.org/confluence/display/solr/Defining+core.properties